### PR TITLE
Set font to bold according to font weight

### DIFF
--- a/xls2xlsx/xls2xlsx.py
+++ b/xls2xlsx/xls2xlsx.py
@@ -113,7 +113,8 @@ class XLS2XLSX:
 
             try:            # Avoidance for issue #11 (though I cannot duplicate the problem w/o the input file)
                 xls_font = self.book.font_list[xf.font_index]       # Font object
-                font.b = xls_font.bold
+                if (xls_font.bold or xls_font.weight == 700): # 700 is equal to bold according to https://xlrd.readthedocs.io/en/latest/api.html
+                    font.b = True
                 font.i = xls_font.italic
                 if xls_font.character_set:
                     font.charset = xls_font.character_set

--- a/xls2xlsx/xls2xlsx.py
+++ b/xls2xlsx/xls2xlsx.py
@@ -115,6 +115,8 @@ class XLS2XLSX:
                 xls_font = self.book.font_list[xf.font_index]       # Font object
                 if (xls_font.bold or xls_font.weight == 700): # 700 is equal to bold according to https://xlrd.readthedocs.io/en/latest/api.html
                     font.b = True
+                else:
+                    font.b = False
                 font.i = xls_font.italic
                 if xls_font.character_set:
                     font.charset = xls_font.character_set


### PR DESCRIPTION
Closes #30 

set the font to bold, if the weight of the font is equal to 700.
According to https://xlrd.readthedocs.io/en/latest/api.html 700 is bold

`Font weight (100-1000). Standard values are 400 for normal text and 700 for bold text.`